### PR TITLE
Fix use of eval_tidy() for rlang 0.1.3

### DIFF
--- a/R/taxonomy--class.R
+++ b/R/taxonomy--class.R
@@ -902,8 +902,7 @@ Taxonomy <- R6::R6Class(
     # Each expression can resolve to taxon ids, edgelist indexes, or logical.
     parse_nse_taxon_subset = function(...) {
       # Non-standard argument evaluation
-      selection <- rlang::eval_tidy(rlang::quos(...),
-                                    data = self$data_used(...))
+      selection <- lapply(rlang::quos(...), rlang::eval_tidy, data = self$data_used(...))
 
       # Default to all taxa if no selection is provided
       if (all(vapply(selection, is.null, logical(1)))) {


### PR DESCRIPTION
This fixes `taxa` for the next version of rlang. In the current CRAN version it maps itself over lists which is a bug. In rlang 0.1.3 `eval_tidy()` will return lists literally just like `base::eval()` does.

Could you please send a new release to CRAN with this fix? We planned the new rlang release (which you can find at https://github.com/tidyverse/rlang/pull/282) for next week.