### PR TITLE
Fixed print bug in Taxon (authority).

### DIFF
--- a/R/taxon.R
+++ b/R/taxon.R
@@ -90,7 +90,7 @@ Taxon <- R6::R6Class(
       cat(paste0(indent, paste0("  id: ",
                                 private$get_id() %||% "none", "\n")))
       cat(paste0(indent, paste0("  authority: ",
-                                private$authority %||% "none", "\n")))
+                                self$authority %||% "none", "\n")))
       invisible(self)
     },
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Update the way Taxon prints the "authority".

## Description
<!--- Describe your changes in detail -->
While it is still contained within the Taxon object, **authority does** not print to console properly.  The __print function__ uses the __private list__, which does not contain the authority attribute.  However, self does and was used to fix the bug.


